### PR TITLE
Changed Grant.otherFunders list to single Grant.directFunder

### DIFF
--- a/documentation/Grant.md
+++ b/documentation/Grant.md
@@ -9,8 +9,8 @@ Grants/awards are received by one or more [Persons](Person.md) and can have 0 or
 | awardStatus | Enum ([_see list below_](#status-options)) | Status of award | 
 | localAwardId 	| String | Award number or ID assigned to the grant within the researcher's institution |
 | projectName* | String | Title of the research project |
-| primaryFunder* | [Funder](Funder.md) | Primary sponsor of grant |
-| otherFunders | List[[Funder](Funder.md)] | Other sponsors of grant |
+| primaryFunder* | [Funder](Funder.md) | The sponsor that is the original source of the funds. This will often be the same as directFunder. |
+| directFunder* | [Funder](Funder.md) | The organization from which funds are directly received. This will often be the same as primaryFunder. |
 | pi* | [Person](Person.md) | Principal investigator |
 | coPis | List[[Person](Person.md)] | Co-principal investigator list |
 | awardDate* | DateTime | Date the grant was awarded |


### PR DESCRIPTION
Out of a discussion with @jrmartino. Each funding source is a new "grant" in the system i.e. grants have a one to one relationship with the original funder.  A grant can, however, have an intermediary organization who receives the funding and then "writes the checks" to other institutions.  For example, where co-pis are in different institutions. This change reflects this - all records should have a primaryFunder and a directFunder that indicate where the money came from and who wrote the check, respectively. These will be the same in most cases.