### PR TITLE
Support normalization of Harvard grant numbers

### DIFF
--- a/documentation/Repository.md
+++ b/documentation/Repository.md
@@ -36,6 +36,7 @@ These are the repository keys currently used in PASS. This list will grow as mor
 | Value  		  | Repository name |
 | --------------- | ------------- |
 | pmc | [PubMed Central](https://www.ncbi.nlm.nih.gov/pmc/) |
-| jscholarship | [JScholarship](https://jscholarship.library.jhu.edu/) |
+| jscholarship | [Johns Hopkins JScholarship](https://jscholarship.library.jhu.edu/) |
 | eric | [Education Resources Information Center](https://eric.ed.gov/) (ERIC) |
 | dec | [Development Experience Clearinghouse](https://dec.usaid.gov/dec/) (DEC) |
+| dash | [Harvard DASH](https://dash.harvard.edu/) |

--- a/src/main/resources/esconfig-3.5.json
+++ b/src/main/resources/esconfig-3.5.json
@@ -1,0 +1,140 @@
+{
+  "settings": {
+    "index" : {
+      "refresh_interval" : "1s"
+    },
+    "analysis": {
+      "char_filter" : {
+        "fedora_uri_to_path" : {
+          "type": "pattern_replace",
+          "pattern": "\\Ahttp.*?/fcrepo/rest",
+          "replacement": ""
+        },
+        "nih_zero_ignore" : {
+          "type": "pattern_replace",
+          "pattern": "\\A[A-Za-z]\\w\\d([A-Za-z][A-Za-z])0{0,4}(\\d{2,6})\\Z",
+          "replacement": "$1$2"
+        },
+        "period_dash_whitespace_ignore" : {
+          "type": "pattern_replace",
+          "pattern": "\\.|-|\\s",
+          "replacement": ""
+        },
+        "nih_ending_suffix_ignore": {
+          "type": "pattern_replace",
+          "pattern": "\\A(.*)-[0-9]*\\Z",
+          "replacement": "$1"
+        },
+        "nih_leading_num_ignore": {
+          "type": "pattern_replace",
+          "pattern": "\\A[0-9]*",
+          "replacement": ""
+        }
+      },
+      "normalizer": {
+        "ignorecase": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["lowercase", "asciifolding"]
+        },
+        "fedora_uri": {
+          "type": "custom",
+          "char_filter": ["fedora_uri_to_path"],
+          "filter": []
+        },
+        "award_number": {
+          "type": "custom",
+          "char_filter": ["nih_leading_num_ignore", "nih_ending_suffix_ignore", "nih_zero_ignore", "period_dash_whitespace_ignore"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": false,      
+      "properties": {
+        "@context": {"type": "keyword", "normalizer": "fedora_uri"},
+        "@id": {"type": "keyword", "normalizer": "fedora_uri"},
+        "@type": {"type": "keyword"},        
+        "abstract": {"type": "text"},
+        "accessUrl": {"type": "keyword"},
+        "affiliation": {"type": "text"},
+        "aggregatedDepositStatus": {"type": "keyword"},
+        "agreementText": {"type": "text"},
+        "awardDate": {"type": "date"},        
+        "awardNumber": {"type": "keyword", "normalizer": "award_number"},
+        "awardStatus": {"type": "keyword"},        
+        "comment": {"type": "text"},
+        "coPis": {"type": "keyword", "normalizer": "fedora_uri"},
+        "copyStatus": {"type": "keyword"},        
+        "depositStatus": {"type": "keyword"},
+        "depositStatusRef": {"type": "keyword"},
+        "description": {"type": "text"},
+        "directFunder": {"type": "keyword", "normalizer": "fedora_uri"},
+        "displayName": {"type": "text", "analyzer": "simple"},        
+        "doi": {"type": "keyword", "normalizer": "ignorecase"},
+        "effectivePolicies": {"type": "keyword", "normalizer": "fedora_uri"},
+        "email": {"type": "keyword", "normalizer": "ignorecase"},
+        "endDate": {"type": "date"},
+        "eventType": {"type": "keyword"},
+        "externalIds": {"type": "keyword", "normalizer": "fedora_uri"},
+        "fileRole": {"type": "keyword"},
+        "firstName": {"type": "text", "analyzer": "simple"},
+        "formSchema": {"type": "keyword"},        
+        "grants": {"type": "keyword", "normalizer": "fedora_uri"},
+        "integrationType": {"type": "keyword"},
+        "institution": {"type": "keyword"},
+        "issue": {"type": "keyword"},
+        "issns": {"type": "keyword"},
+        "lastName": {"type": "text", "analyzer": "simple"},
+        "locatorIds": {"type": "keyword"},
+        "journal": {"type": "keyword", "normalizer": "fedora_uri"},
+        "journalName": {"type": "text"},
+        "journalName_suggest": {"type": "completion"},   
+        "localKey": {"type": "keyword"},
+        "link": {"type": "keyword", "normalizer": "fedora_uri"},
+        "metadata": {"type": "text"},
+        "middleName": {"type": "text", "analyzer": "simple"},
+        "mimeType": {"type": "keyword"},        
+        "name": {"type": "text"},
+        "nlmta": {"type": "keyword"},
+        "orcidId": {"type": "keyword"},        
+        "performedDate": {"type": "date"},
+        "performedBy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "performerRole": {"type": "keyword"},
+        "pi": {"type": "keyword", "normalizer": "fedora_uri"},
+        "pmcParticipation": {"type": "keyword"},
+        "pmid": {"type": "keyword"},
+        "policy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "policyUrl": {"type": "keyword"},
+        "preparers": {"type": "keyword", "normalizer": "fedora_uri"},
+        "primaryFunder": {"type": "keyword", "normalizer": "fedora_uri"},        
+        "projectName": {"type": "text"},
+        "publisher": {"type": "keyword", "normalizer": "fedora_uri"},
+        "publication": {"type": "keyword", "normalizer": "fedora_uri"},        
+        "repository": {"type": "keyword", "normalizer": "fedora_uri"},
+        "repositoryKey": {"type": "keyword"},
+        "repositoryCopy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "repositories": {"type": "keyword", "normalizer": "fedora_uri"},        
+        "roles": {"type": "keyword"},
+	"schemas": {"type": "keyword"},
+        "source": {"type": "keyword"},        
+        "startDate": {"type": "date"},
+        "submission": {"type": "keyword", "normalizer": "fedora_uri"},
+        "submissionStatus": {"type": "keyword"},
+        "submitted": {"type": "boolean"},
+        "submittedDate": {"type": "date"},
+        "submitter": {"type": "keyword", "normalizer": "fedora_uri"},
+        "submitterEmail": {"type": "keyword"},
+        "submitterName": {"type": "text", "analyzer": "simple"},
+        "title": {"type": "text"},        
+        "uri": {"type": "keyword"},
+        "url": {"type": "keyword"},
+        "user": {"type": "keyword", "normalizer": "fedora_uri"},        
+        "username": {"type": "keyword"},
+        "volume": {"type": "keyword"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Warning
**N.B.** This PR shouldn't be merged until the Harvard `assets` container is completed.  However, the Elastic Search config present in this PR *should* be used when building assets, by setting the indexer's `PI_ES_CONFIG` environment variable to `https://raw.githubusercontent.com/emetsger/pass-data-model/dash/src/main/resources/esconfig-3.5.json` in the interim.  Building Harvard assets, then running the various loaders, especially the PACM (NIHMS ETL) data load will insure that the additional changes in this configuration are stable.  After the assets image has been created, tagged, and merged in to `pass-docker`, this PR can be merged.

### About
Version 3.5 of the Elastic Search config, supporting additional normalizations of `Grant.awardNumber` for Harvard grant data    
- adds two character filters for the `award_number` normalizer
    - `nih_ending_suffix_ignore` ignores what appears to be a sequence number like `-01` or `-03` at the end of an award number
    - `nih_leading_num_ignore` ignores any leading digits at the beginning of an award number    

An example is Harvard award number `1F32GM128267-02` which needs to be matched as `F32GM128267`, absent any leading digits or sequence suffix

This pr also updates the README, documenting `dash` as a possible value for `Repository.repositoryKey`.